### PR TITLE
Updating THREE.Geometry to THREE.BufferGeometry r125

### DIFF
--- a/index.js
+++ b/index.js
@@ -453,16 +453,16 @@ THREE.Lut.prototype = {
 
                 var material = new THREE.LineBasicMaterial( { color: 0x000000, linewidth: 2 } );
 
-                var geometry = new THREE.Geometry();
+                var points = [];
 
 
                 if ( this.legend.layout == 'vertical' ) {
 
                     var linePosition = ( this.legend.position.y - ( this.legend.dimensions.height * 0.5 ) + 0.01 ) + ( this.legend.dimensions.height ) * ( ( value - this.minV ) / ( this.maxV - this.minV ) * 0.99 );
 
-                    geometry.vertices.push( new THREE.Vector3( this.legend.position.x + this.legend.dimensions.width * 0.55, linePosition, this.legend.position.z  ) );
+                    points.push( new THREE.Vector3( this.legend.position.x + this.legend.dimensions.width * 0.55, linePosition, this.legend.position.z  ) );
 
-                    geometry.vertices.push( new THREE.Vector3( this.legend.position.x + this.legend.dimensions.width * 0.7, linePosition, this.legend.position.z  ) );
+                    points.push( new THREE.Vector3( this.legend.position.x + this.legend.dimensions.width * 0.7, linePosition, this.legend.position.z  ) );
 
                 }
 
@@ -470,12 +470,13 @@ THREE.Lut.prototype = {
 
                     var linePosition = ( this.legend.position.x - ( this.legend.dimensions.height * 0.5 ) + 0.01 ) + ( this.legend.dimensions.height ) * ( ( value - this.minV ) / ( this.maxV - this.minV ) * 0.99 );
 
-                    geometry.vertices.push( new THREE.Vector3( linePosition, this.legend.position.y - this.legend.dimensions.width * 0.55, this.legend.position.z  ) );
+                    points.push( new THREE.Vector3( linePosition, this.legend.position.y - this.legend.dimensions.width * 0.55, this.legend.position.z  ) );
 
-                    geometry.vertices.push( new THREE.Vector3( linePosition, this.legend.position.y - this.legend.dimensions.width * 0.7, this.legend.position.z  ) );
+                    points.push( new THREE.Vector3( linePosition, this.legend.position.y - this.legend.dimensions.width * 0.7, this.legend.position.z  ) );
 
                 }
 
+                var geometry = new THREE.BufferGeometry().setFromPoints(points);
                 var line = new THREE.Line( geometry, material );
 
                 lines[ i ] = line;


### PR DESCRIPTION
Three r125 contained a major breaking change from previous versions. THREE.Geometry is deprecated and now you need to use  THREE.BufferGeometry because  all inbuilt geometries now derive from that.

